### PR TITLE
fix: concurrent boot webcontainer

### DIFF
--- a/composables/webContainer.ts
+++ b/composables/webContainer.ts
@@ -1,9 +1,9 @@
 import { WebContainer } from '@webcontainer/api'
 
-let _webcontainerInstance: WebContainer
+let _webcontainerPromise: Promise<WebContainer>
 
 export async function useWebContainer() {
-  if (!_webcontainerInstance)
-    _webcontainerInstance = await WebContainer.boot()
-  return _webcontainerInstance
+  if (!_webcontainerPromise)
+    _webcontainerPromise = WebContainer.boot()
+  return await _webcontainerPromise
 }


### PR DESCRIPTION
Trigger the `useWebContainer` multiple times before it first finish booting, it will call `WebContainer.boot()` multiple times and may break https://webcontainers.io/guides/quickstart#_1-create-a-webcontainer-instance

See the following simple code snippets

```js
function sleep(t = 1000) {
  return new Promise(res => {
    console.log('Sleep', t);
    setTimeout(() => res(1), t);
  });
}

let ins;
async function useInstance() {
  if (!ins) ins = await sleep();
  return ins;
}

useInstance();
useInstance();
useInstance();

// Log:
// Sleep 1000
// Sleep 1000
// Sleep 1000
// Not:
// Sleep 1000
```