### PR TITLE
fix(color-mode): use color.preference & use select

### DIFF
--- a/components/ColorSchemeToggle.vue
+++ b/components/ColorSchemeToggle.vue
@@ -1,0 +1,14 @@
+<script lang="ts" setup>
+const colorMode = useColorMode()
+
+const toggleMode = () => colorMode.value = colorMode.value === 'light' ? 'dark' : 'light'
+</script>
+
+<template>
+  <button
+    class="p-2 rounded hover:bg-active"
+    @click="toggleMode"
+  >
+    <div class="i-carbon-moon dark:i-carbon-sun " />
+  </button>
+</template>

--- a/components/TheNav.vue
+++ b/components/TheNav.vue
@@ -3,6 +3,7 @@
     <div i-logos-nuxt-icon text-4xl />
     <span text-2xl>learn.nuxt.com</span>
     <div flex-auto />
+    <ColorSchemeToggle />
     <NuxtLink
       p2 rounded
       hover="bg-active"

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,12 +1,8 @@
 <script setup lang="ts">
 const { x, y } = useMouse()
-const color = useColorMode()
 
-function toggleDark() {
-  color.value = color.value === 'dark'
-    ? 'light'
-    : 'dark'
-}
+const color = useColorMode()
+const colorSchemes = ['light', 'dark', 'system']
 </script>
 
 <template>
@@ -16,9 +12,11 @@ function toggleDark() {
       <div class="text-red">
         Hello World {{ x }}, {{ y }}<br>
 
-        <button @click="toggleDark">
-          {{ color.value }}
-        </button>
+        <select v-model="color.preference">
+          <option v-for="scheme in colorSchemes" :key="scheme" :value="scheme">
+            {{ scheme }}
+          </option>
+        </select>
       </div>
     </div>
     <ThePlayground />

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,8 +1,5 @@
 <script setup lang="ts">
 const { x, y } = useMouse()
-
-const color = useColorMode()
-const colorSchemes = ['light', 'dark', 'system']
 </script>
 
 <template>
@@ -11,12 +8,6 @@ const colorSchemes = ['light', 'dark', 'system']
       Content
       <div class="text-red">
         Hello World {{ x }}, {{ y }}<br>
-
-        <select v-model="color.preference">
-          <option v-for="scheme in colorSchemes" :key="scheme" :value="scheme">
-            {{ scheme }}
-          </option>
-        </select>
       </div>
     </div>
     <ThePlayground />


### PR DESCRIPTION
- Use `colorMode.preference` as `colorMode.value` is meant to be read-only. https://color-mode.nuxtjs.org/#usage
- Use a `<select>` instead of a button to add `system` option

Edit: I moved the logic into a toggle component and just use the original `colorMode.value`.
![CleanShot 2023-11-23 at 10 06 06](https://github.com/nuxt/learn.nuxt.com/assets/18753964/63713924-3ba2-4ecc-819b-20d6bcf1186d)
