### PR TITLE
chore: invert icons

### DIFF
--- a/components/ColorSchemeToggle.vue
+++ b/components/ColorSchemeToggle.vue
@@ -9,6 +9,6 @@ const toggleMode = () => colorMode.value = colorMode.value === 'light' ? 'dark' 
     class="p-2 rounded hover:bg-active"
     @click="toggleMode"
   >
-    <div class="i-carbon-moon dark:i-carbon-sun " />
+    <div class="i-carbon-sun dark:i-carbon-moon" />
   </button>
 </template>


### PR DESCRIPTION
The icon's orientation in colorMode has been reversed.
![Nuxt Icon](https://github.com/nuxt/learn.nuxt.com/assets/57829584/ad643ac1-0975-4305-ac7d-c8757b068ea3)
