### PR TITLE
fix: including `.npmrc` for the basic template

### DIFF
--- a/components/ThePlayground.client.vue
+++ b/components/ThePlayground.client.vue
@@ -21,6 +21,7 @@ async function startDevServer() {
     '../templates/basic/',
     import.meta.glob([
       '../templates/basic/**/*.*',
+      '../templates/basic/**/.npmrc',
       '!**/node_modules/**',
     ], {
       as: 'raw',

--- a/components/ThePlayground.client.vue
+++ b/components/ThePlayground.client.vue
@@ -21,7 +21,8 @@ async function startDevServer() {
     '../templates/basic/',
     import.meta.glob([
       '../templates/basic/**/*.*',
-      '../templates/basic/**/.npmrc',
+      '../templates/basic/**/.*',
+      '!../.DS_Store',
       '!**/node_modules/**',
     ], {
       as: 'raw',


### PR DESCRIPTION
If `{ exhaustive: true }` is not set in `import.meta.glob`, files starting with `.*` are not included by default, so I manually added `.npmrc`.