### PR TITLE
fix: prevent unexpected reloading to fix `entry.js` response html

### DIFF
--- a/components/ThePlayground.client.vue
+++ b/components/ThePlayground.client.vue
@@ -33,8 +33,8 @@ async function startDevServer() {
   const wc = await useWebContainer()
 
   wc.on('server-ready', (port, url) => {
-    // XXX: This is a hack to avoid the iframe to be reloaded when the nuxt server restarts
-    if (status.value !== 'ready') {
+    // prevent reloading iframe when nuxt server starting other target ports
+    if (port === 3000) {
       status.value = 'ready'
       wcUrl.value = url
     }

--- a/components/ThePlayground.client.vue
+++ b/components/ThePlayground.client.vue
@@ -33,8 +33,11 @@ async function startDevServer() {
   const wc = await useWebContainer()
 
   wc.on('server-ready', (port, url) => {
-    status.value = 'ready'
-    wcUrl.value = url
+    // XXX: This is a hack to avoid the iframe to be reloaded when the nuxt server restarts
+    if (status.value !== 'ready') {
+      status.value = 'ready'
+      wcUrl.value = url
+    }
   })
 
   wc.on('error', (err) => {

--- a/components/ThePlayground.client.vue
+++ b/components/ThePlayground.client.vue
@@ -33,7 +33,8 @@ async function startDevServer() {
   const wc = await useWebContainer()
 
   wc.on('server-ready', (port, url) => {
-    // prevent reloading iframe when nuxt server starting other target ports
+    // Nuxt listen to multiple ports, and 'server-ready' is emitted for each of them
+    // We need the main one
     if (port === 3000) {
       status.value = 'ready'
       wcUrl.value = url


### PR DESCRIPTION
After my testing, I found that the Nuxt server undergoes several instances of unexpected reloading after the dev server starts. This causes `entry.js` to respond with HTML. I consider this a temporary solution and believe there should be a more elegant approach.