### PR TITLE
fix: init pane size mistake when left pane size 100

### DIFF
--- a/components/PanelTerminal.vue
+++ b/components/PanelTerminal.vue
@@ -10,7 +10,6 @@ const props = defineProps<{
 const root = ref<HTMLDivElement>()
 const terminal = new Terminal({
   customGlyphs: true,
-  lineHeight: 0.9,
 })
 const fitAddon = new FitAddon()
 terminal.loadAddon(fitAddon)

--- a/pages/[...slug].vue
+++ b/pages/[...slug].vue
@@ -20,7 +20,7 @@ function end(e: { size: number }[]) {
     <Pane :size="leftSize" min-size="10">
       <PanelGuide />
     </Pane>
-    <Pane>
+    <Pane :size="100 - leftSize">
       <ThePlayground />
     </Pane>
   </Splitpanes>


### PR DESCRIPTION
- xterm `line-height` cannot be less than 1
https://github.com/xtermjs/xterm.js/blob/fb2c39cb5748e071e0a1ed49824590aafd45e65e/src/common/services/OptionsService.ts#L165-L170

- init right pane size mistake when left size is 100

https://github.com/nuxt/learn.nuxt.com/assets/54026110/4683745a-4ff2-45be-9664-7bd321abbc64

