### PR TITLE
refactor: simplify types in playground store

### DIFF
--- a/components/MainPlayground.vue
+++ b/components/MainPlayground.vue
@@ -80,7 +80,7 @@ const panelInitTerminal = computed(() => isMounted.value || {
         @resized="endDraggingHorizontal"
       >
         <Pane :size="ui.panelEditor" min-size="10" :style="panelInitEditor">
-          <PanelEditor :files="play?.files" />
+          <PanelEditor :files="play.files" />
         </Pane>
         <PaneSplitter />
         <Pane :size="ui.panelPreview" min-size="10" :style="panelInitPreview">
@@ -91,7 +91,7 @@ const panelInitTerminal = computed(() => isMounted.value || {
           v-bind="terminalPaneProps" :style="panelInitTerminal"
           :class="ui.showTerminal ? '' : 'pane-hidden'"
         >
-          <PanelTerminal :stream="play?.stream" />
+          <PanelTerminal :stream="play.stream" />
         </Pane>
       </Splitpanes>
     </Pane>

--- a/composables/web-container.ts
+++ b/composables/web-container.ts
@@ -5,7 +5,7 @@
 
 import type { WebContainerProcess } from '@webcontainer/api'
 import { WebContainer } from '@webcontainer/api'
-import type { PlaygroundState } from '../stores/playground'
+import type { PlaygroundStore } from '../stores/playground'
 import { templates } from '~/templates'
 
 if (import.meta.server)
@@ -20,7 +20,7 @@ export async function useWebContainer() {
 }
 
 export async function mountPlayground(
-  play: PlaygroundState,
+  play: PlaygroundStore,
   colorMode: string,
 ) {
   const { files, tree } = await templates.basic({

--- a/stores/playground.ts
+++ b/stores/playground.ts
@@ -1,5 +1,4 @@
-import { defineStore } from 'pinia'
-import type { Raw, ShallowRef, UnwrapNestedRefs } from 'vue'
+import type { Raw } from 'vue'
 import type { WebContainer } from '@webcontainer/api'
 import type { VirtualFile } from '../structures/VirtualFile'
 
@@ -13,28 +12,18 @@ export const PlaygroundStatusOrder = [
 
 export type PlaygroundStatus = typeof PlaygroundStatusOrder[number] | 'error'
 
-export interface PlaygroundStateRaw {
-  files: ShallowRef<Raw<VirtualFile[]>>
-  status: PlaygroundStatus
-  error: { message: string } | undefined
-  stream: ReadableStream | undefined
-  webcontainer: ShallowRef<Raw<WebContainer> | undefined>
-  previewUrl: ComputedRef<string>
-  previewLocation: Ref<{
-    origin: string
-    fullPath: string
-  }>
-  actions: PlaygroundActions
-}
-
 export interface PlaygroundActions {
   restartServer(): Promise<void>
   downloadZip(): Promise<void>
 }
 
-export type PlaygroundState = UnwrapNestedRefs<PlaygroundStateRaw>
+export const usePlaygroundStore = defineStore('playground', () => {
+  const status = ref<PlaygroundStatus>('init')
+  const error = shallowRef<{ message: string }>()
+  const stream = shallowRef<ReadableStream>()
+  const files = shallowRef<Raw<VirtualFile>[]>([])
+  const webcontainer = shallowRef<Raw<WebContainer>>()
 
-export const usePlaygroundStore = defineStore('playground', (): PlaygroundStateRaw => {
   const previewLocation = ref({
     origin: '',
     fullPath: '',
@@ -48,16 +37,18 @@ export const usePlaygroundStore = defineStore('playground', (): PlaygroundStateR
   }
 
   return {
-    status: 'init',
-    error: undefined,
-    stream: undefined,
-    files: shallowRef([]),
-    webcontainer: shallowRef(undefined),
+    status,
+    error,
+    stream,
+    files,
+    webcontainer,
     previewUrl,
     previewLocation,
     actions,
   }
 })
+
+export type PlaygroundStore = ReturnType<typeof usePlaygroundStore>
 
 if (import.meta.hot)
   import.meta.hot.accept(acceptHMRUpdate(usePlaygroundStore, import.meta.hot))


### PR DESCRIPTION
Hello! These are just my recommendations to make the types simpler in Pinia. It revolves around letting pinia infer the final types for you and using `export type PlaygroundStore = ReturnType<typeof usePlaygroundStore>` to infer the final store type used by `mountPlayground()`.

One thing I would personally also do is move (back) the `mountPlayground` to the store and refactor the `actions` object so they can be regular actions without replacing them at mount. I didn't include those changes to make this refactor clear but let me know if you want me to also add it.

I could also come during a stream to explain some of the things if you want, or I can just do it from the chat too.

I didn't know about `Raw<T>`, I think I should improve pinia types so adding this manually isn't necessary.