### PR TITLE
feat: add interactivity

### DIFF
--- a/components/MainPlayground.vue
+++ b/components/MainPlayground.vue
@@ -91,7 +91,7 @@ const panelInitTerminal = computed(() => isMounted.value || {
           v-bind="terminalPaneProps" :style="panelInitTerminal"
           :class="ui.showTerminal ? '' : 'pane-hidden'"
         >
-          <PanelTerminal :stream="play.stream" />
+          <PanelTerminal :stream="play.outputStream" />
         </Pane>
       </Splitpanes>
     </Pane>

--- a/components/PanelPreviewLoading.vue
+++ b/components/PanelPreviewLoading.vue
@@ -40,6 +40,9 @@ function getTextClass(status: PlaygroundStatus) {
       return 'op50'
   }
 }
+
+const isLethargicTerm = computed(() => play.termInteractType === 'lethargic')
+
 </script>
 
 <template>
@@ -53,10 +56,12 @@ function getTextClass(status: PlaygroundStatus) {
       <span :class="getTextClass('init')">Initialize WebContainer</span>
       <div :class="getStatusIcon('mount')" />
       <span :class="getTextClass('mount')">Mount files</span>
-      <div :class="getStatusIcon('install')" />
-      <span :class="getTextClass('install')">Install Dependencies</span>
-      <div :class="getStatusIcon('start')" />
-      <span :class="getTextClass('start')">Boot Nuxt Server</span>
+      <div v-if="isLethargicTerm" :class="getStatusIcon('install')" />
+      <span v-if="isLethargicTerm" :class="getTextClass('install')">Install Dependencies</span>
+      <div v-if="isLethargicTerm" :class="getStatusIcon('start')" />
+      <span v-if="isLethargicTerm" :class="getTextClass('start')">Boot Nuxt Server</span>
+      <div class="i-ph-dot-duotone text-xl" />
+      <span class="op50 normal-case">Execute Commands 'pnpm install' & 'pnpm dev' to Start. </span>
     </div>
   </div>
 </template>

--- a/components/PanelTerminalClient.client.vue
+++ b/components/PanelTerminalClient.client.vue
@@ -23,6 +23,7 @@ const theme = computed<ITheme>(() => {
 
 const root = ref<HTMLDivElement>()
 const terminal = new Terminal({
+  convertEol: true,
   customGlyphs: true,
   allowTransparency: true,
   theme: theme.value,
@@ -40,7 +41,7 @@ const fitAddon = new FitAddon()
 terminal.loadAddon(fitAddon)
 
 watch(
-  () => play.stream,
+  () => play.outputStream,
   (s) => {
     if (!s)
       return
@@ -60,6 +61,23 @@ watch(
     }
   },
   { flush: 'sync', immediate: true },
+)
+
+watch(
+  () => play.inputStream,
+  (ipts) => {
+    if(!ipts)
+      return
+    try {
+      const input = ipts.getWriter()
+      terminal.onData((data) => {
+        input.write(data);
+      });
+    } catch (e) {
+      console.log(e)
+    }
+  },
+  { flush: 'sync', immediate: true }
 )
 
 useResizeObserver(root, useDebounceFn(() => fitAddon.fit(), 200))


### PR DESCRIPTION
Hello, Antfu! Caught your YouTube stream last night, intrigued by learn.nuxt. It's my debut in open-source (1st PR submission) in my career. Here's what I've done:
I've changed TREM's default 'install & start' to 'interactivity' and Users can manually install and start in the terminal after 'Initialize WebContainer & Mount Files' like this:
![3511701842925_ pic](https://github.com/nuxt/learn.nuxt.com/assets/47271407/916c85aa-ba53-403c-851f-99d29d2322da)

Appearance after successful startup:

![3521701842969_ pic](https://github.com/nuxt/learn.nuxt.com/assets/47271407/c5ee83f7-0f1e-4390-b395-1ff617835367)

I wasn't sure how you'd want to handle the previous default startup settings, so I've kept them intact. You can see my approach in playground.ts.
