### PR TITLE
fix: add node_modules to INGORE_FILES

### DIFF
--- a/composables/files-ignore.ts
+++ b/composables/files-ignore.ts
@@ -1,6 +1,7 @@
 const INGORE_FILES: (string | RegExp)[] = [
   'pnpm-lock.yaml',
   'pnpm-workspace.yaml',
+  'node_modules',
   /tsconfig\.json$/,
   /^\./,
 ]


### PR DESCRIPTION
Aha, I don't think this PR is worth mentioning. I hope I didn't do the wrong thing, make the wrong changes. 

Last night, I saw your live stream and thought about downloading it. 
I clicked on the download and found that there was a node_modules folder inside. 
It looked a little strange. So quickly put up a PR.

You might have fixed it, or it might be designed to contain node_modules, I do not understand your design intent, if good intentions do bad things, please do not be angry.
