### PR TITLE
feat: add interactivity shell 2.0

### DIFF
--- a/components/PanelPreview.vue
+++ b/components/PanelPreview.vue
@@ -15,6 +15,15 @@ function refreshIframe() {
   }
 }
 
+watch(
+  () => play.previewUrl,
+  () => {
+    if(play.status === 'ready')
+      refreshIframe()
+  },
+  { flush: 'sync' }
+)
+
 function navigate() {
   play.previewLocation.fullPath = inputUrl.value
   play.updatePreviewUrl()

--- a/components/PanelTerminalClient.client.vue
+++ b/components/PanelTerminalClient.client.vue
@@ -40,7 +40,7 @@ const fitAddon = new FitAddon()
 terminal.loadAddon(fitAddon)
 
 watch(
-  () => play.stream,
+  () => play.outputStream,
   (s) => {
     if (!s)
       return
@@ -58,6 +58,20 @@ watch(
     catch (e) {
       console.error(e)
     }
+  },
+  { flush: 'sync', immediate: true },
+)
+
+watch(
+  () => play.inputStream,
+  (ips) => {
+    if(!ips)
+      return
+    const input = ips.getWriter()
+    terminal.onData((data) => {
+      play.killPreviousProcess()
+      input.write(data)
+    })
   },
   { flush: 'sync', immediate: true },
 )


### PR DESCRIPTION
Hello, Antfu!  I've made fresh attempts and coded a new interactivity shell!!!
And now, it work! first time auto-start, then user can able to interpret the Nuxt process with Ctrl+C!
And it can be relaunched using 'pnpm run dev'!!

this is first time auto-start:
<img width="1355" alt="屏幕截图 2023-12-07 001258" src="https://github.com/nuxt/learn.nuxt.com/assets/47271407/5d0221b7-c744-4e65-bd29-004227c8ce30">

then 'pnpm run dev' to start!:

<img width="1357" alt="屏幕截图 2023-12-07 001455" src="https://github.com/nuxt/learn.nuxt.com/assets/47271407/d50851b3-4b14-461a-b2f9-336ac12ea25f">

As u can see, its work! but we have a new issues about, if this way is TRUE, maybe we need redesign the PlaygroundStatus! 
Beacuse if the user presses Ctrl+C during installation, the previous state should be successful!