### PR TITLE
feat: add interactivity shell(auto&interact)

### DIFF
--- a/components/MainPlayground.vue
+++ b/components/MainPlayground.vue
@@ -91,7 +91,7 @@ const panelInitTerminal = computed(() => isMounted.value || {
           v-bind="terminalPaneProps" :style="panelInitTerminal"
           :class="ui.showTerminal ? '' : 'pane-hidden'"
         >
-          <PanelTerminal :stream="play.stream" />
+          <PanelTerminal :stream="play.inputStream" />
         </Pane>
       </Splitpanes>
     </Pane>

--- a/components/PanelPreview.vue
+++ b/components/PanelPreview.vue
@@ -15,6 +15,15 @@ function refreshIframe() {
   }
 }
 
+watch(
+  () => play.previewUrl,
+  () => {
+    if(play.status === 'ready')
+      refreshIframe()
+  },
+  { flush: 'sync' }
+)
+
 function navigate() {
   play.previewLocation.fullPath = inputUrl.value
   play.updatePreviewUrl()

--- a/components/PanelTerminalClient.client.vue
+++ b/components/PanelTerminalClient.client.vue
@@ -40,7 +40,7 @@ const fitAddon = new FitAddon()
 terminal.loadAddon(fitAddon)
 
 watch(
-  () => play.stream,
+  () => play.outputStream,
   (s) => {
     if (!s)
       return
@@ -58,6 +58,20 @@ watch(
     catch (e) {
       console.error(e)
     }
+  },
+  { flush: 'sync', immediate: true },
+)
+
+watch(
+  () => play.inputStream,
+  (ips) => {
+    if(!ips)
+      return
+    const input = ips.getWriter()
+    terminal.onData((data) => {
+      play.killPreviousProcess()
+      input.write(data)
+    })
   },
   { flush: 'sync', immediate: true },
 )


### PR DESCRIPTION
Hello, Antfu! I've made fresh attempts and coded a new interactivity shell!!!
And now, it work! first time auto-start, then user can able to interpret the Nuxt process with Ctrl+C!
And it can be relaunched using 'pnpm run dev'!!

this is first time auto-start:
![image](https://github.com/nuxt/learn.nuxt.com/assets/47271407/1f034fb2-7c4f-4f4f-9bdf-7617ed7ac898)
then 'pnpm run dev' to start!:
![image](https://github.com/nuxt/learn.nuxt.com/assets/47271407/b98121cf-675c-450a-b296-062e5106e9ed)
