### PR TITLE
feat: add interactivity shell after user terminiate Nuxt server

### DIFF
--- a/components/MainPlayground.vue
+++ b/components/MainPlayground.vue
@@ -91,7 +91,7 @@ const panelInitTerminal = computed(() => isMounted.value || {
           v-bind="terminalPaneProps" :style="panelInitTerminal"
           :class="ui.showTerminal ? '' : 'pane-hidden'"
         >
-          <PanelTerminal :stream="play.stream" />
+          <PanelTerminal :stream="play.inputStream" />
         </Pane>
       </Splitpanes>
     </Pane>

--- a/components/MainPlayground.vue
+++ b/components/MainPlayground.vue
@@ -91,7 +91,7 @@ const panelInitTerminal = computed(() => isMounted.value || {
           v-bind="terminalPaneProps" :style="panelInitTerminal"
           :class="ui.showTerminal ? '' : 'pane-hidden'"
         >
-          <PanelTerminal :stream="play.inputStream" />
+          <PanelTerminal />
         </Pane>
       </Splitpanes>
     </Pane>

--- a/components/PanelPreview.vue
+++ b/components/PanelPreview.vue
@@ -15,6 +15,15 @@ function refreshIframe() {
   }
 }
 
+watch(
+  () => play.previewUrl,
+  () => {
+    if(play.status === 'ready')
+      refreshIframe()
+  },
+  { flush: 'sync' }
+)
+
 function navigate() {
   play.previewLocation.fullPath = inputUrl.value
   play.updatePreviewUrl()

--- a/components/PanelPreview.vue
+++ b/components/PanelPreview.vue
@@ -8,20 +8,20 @@ const inner = ref<{ iframe?: HTMLIFrameElement | undefined }>()
 syncRef(computed(() => play.previewLocation.fullPath), inputUrl, { direction: 'ltr' })
 
 function refreshIframe() {
+  play.updatePreviewUrl()
   if (play.previewUrl && inner.value?.iframe) {
-    play.updatePreviewUrl()
     inner.value.iframe.src = play.previewUrl
     inputUrl.value = play.previewLocation.fullPath
   }
 }
 
 watch(
-  () => play.previewUrl,
-  () => {
-    if(play.status === 'ready')
+  () => play.status,
+  (status) => {
+    if (status === 'ready' || status === 'start')
       refreshIframe()
   },
-  { flush: 'sync' }
+  { flush: 'sync' },
 )
 
 function navigate() {

--- a/components/PanelTerminalClient.client.vue
+++ b/components/PanelTerminalClient.client.vue
@@ -40,7 +40,7 @@ const fitAddon = new FitAddon()
 terminal.loadAddon(fitAddon)
 
 watch(
-  () => play.stream,
+  () => play.outputStream,
   (s) => {
     if (!s)
       return
@@ -58,6 +58,20 @@ watch(
     catch (e) {
       console.error(e)
     }
+  },
+  { flush: 'sync', immediate: true },
+)
+
+watch(
+  () => play.inputStream,
+  (ips) => {
+    if(!ips)
+      return
+    const input = ips.getWriter()
+    terminal.onData((data) => {
+      play.killPreviousProcess()
+      input.write(data)
+    })
   },
   { flush: 'sync', immediate: true },
 )

--- a/components/PanelTerminalClient.client.vue
+++ b/components/PanelTerminalClient.client.vue
@@ -40,15 +40,17 @@ const fitAddon = new FitAddon()
 terminal.loadAddon(fitAddon)
 
 watch(
-  () => play.outputStream,
-  (s) => {
-    if (!s)
+  () => play.currentProcess,
+  (p) => {
+    if (!p)
       return
+    // Output
     try {
-      const reader = s.getReader()
+      const reader = p.output.getReader()
       function read() {
         reader.read().then(({ done, value }) => {
-          terminal.write(value)
+          if (value)
+            terminal.write(value)
           if (!done)
             read()
         })
@@ -58,20 +60,16 @@ watch(
     catch (e) {
       console.error(e)
     }
-  },
-  { flush: 'sync', immediate: true },
-)
 
-watch(
-  () => play.inputStream,
-  (ips) => {
-    if(!ips)
-      return
-    const input = ips.getWriter()
-    terminal.onData((data) => {
-      play.killPreviousProcess()
-      input.write(data)
-    })
+    try {
+      const writer = p.input.getWriter()
+      terminal.onData((data) => {
+        writer.write(data)
+      })
+    }
+    catch (e) {
+      console.error(e)
+    }
   },
   { flush: 'sync', immediate: true },
 )

--- a/stores/playground.ts
+++ b/stores/playground.ts
@@ -58,18 +58,17 @@ export const usePlaygroundStore = defineStore('playground', () => {
         // Nuxt listen to multiple ports, and 'server-ready' is emitted for each of them
         // We need the main one
         if (port === 3000) {
-          previewUrl.value = ''
           previewLocation.value = {
             origin: url,
             fullPath: '/',
           }
-          updatePreviewUrl()
+          status.value = 'start'
         }
       })
 
       wc.on('error', (err) => {
-        status.value = 'error'
         error.value = err
+        status.value = 'error'
       })
 
       status.value = 'mount'
@@ -143,7 +142,6 @@ export const usePlaygroundStore = defineStore('playground', () => {
       throw new Error('Unable to run npm install')
     }
 
-    status.value = 'start'
     await spawn(wc, 'pnpm', ['run', 'dev', '--no-qr'])
   }
 
@@ -211,7 +209,6 @@ export const usePlaygroundStore = defineStore('playground', () => {
     previewLocation,
     restartServer: startServer,
     downloadZip,
-    killPreviousProcess,
   }
 })
 


### PR DESCRIPTION
Hello, Antfu! I've made fresh attempts and coded a new interactivity shell!!!
And now, it work! first time auto-start, then user can able to interpret the Nuxt process with Ctrl+C!
And it can be relaunched using 'pnpm run dev'!!

this is first time auto-start:
![image](https://github.com/nuxt/learn.nuxt.com/assets/47271407/967939b9-90a5-4bbe-938c-8dbe4991add8)
then 'pnpm run dev' to start!:
![image](https://github.com/nuxt/learn.nuxt.com/assets/47271407/7f2467bc-b4e9-4eb5-aa42-4bf404bf6de9)