### PR TITLE
fix: enable command continuation post-install interruption.

### DIFF
--- a/stores/playground.ts
+++ b/stores/playground.ts
@@ -143,7 +143,6 @@ export const usePlaygroundStore = defineStore('playground', () => {
       error.value = {
         message: `Unable to run npm install, exit as ${installExitCode}`,
       }
-      // throw new Error('Unable to run npm install')
       console.error('Unable to run npm install')
       return
     }

--- a/stores/playground.ts
+++ b/stores/playground.ts
@@ -143,7 +143,9 @@ export const usePlaygroundStore = defineStore('playground', () => {
       error.value = {
         message: `Unable to run npm install, exit as ${installExitCode}`,
       }
-      throw new Error('Unable to run npm install')
+      // throw new Error('Unable to run npm install')
+      console.error('Unable to run npm install')
+      return
     }
 
     await spawn(wc, 'pnpm', ['run', 'dev', '--no-qr'])


### PR DESCRIPTION
Hello! antfu!
I just spotted a small snag: if someone hits Control + C while installing dependencies, maybe we should let them keep typing commands in the terminal to finish the install and get things running?
This 'throw' stops the program, so 'launchInteractiveProcess' doesn't run, and the terminal can't take input.
![image](https://github.com/nuxt/learn.nuxt.com/assets/47271407/3628ae9b-6fde-493d-9aee-a4c137b9781c)
