### PR TITLE
fix(template): use semver version of `packageManager`

### DIFF
--- a/templates/basic/package.json
+++ b/templates/basic/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "packageManager": "pnpm@^8",
+  "packageManager": "pnpm@8.11.0",
   "scripts": {
     "dev": "nuxt dev",
     "prepare": "nuxt prepare"


### PR DESCRIPTION
For using Corepack to read `packageManager` config of `package.json`, we must specific a semver version to prevent following error:

```
Usage Error: Invalid package manager specification in package.json; expected a semver version
```

FYI, after my testing, web container will not read `packageManager` by default and it always use a default version (8.10.5 currently). Therefore the purpose of setting the `packageManager` for now is for the exported zip and development usage.
