### PR TITLE
fix: include `.layer-playground` in template correctly

### DIFF
--- a/templates/basic/.layer-playground/nuxt.config.ts
+++ b/templates/basic/.layer-playground/nuxt.config.ts
@@ -18,7 +18,7 @@ export default defineNuxtConfig({
     includeWorkspace: true,
     tsConfig: {
       include: [
-        './.layer-playground/**',
+        '../.layer-playground/**/*',
       ],
     },
   },


### PR DESCRIPTION
There are 2 problems from the original `./.layer-playground/**` config.

1. The `tsconfig` does not allow a file to end with `**`. The error message is:
![ts-error](https://github.com/nuxt/learn.nuxt.com/assets/44749100/cb305150-5edb-4d03-9ea3-48d905264f71)

2. When executing Nuxt in the `basic` folder, it generates a build folder in `basic/.nuxt` which includes `tsconfig`. Therefore, the relative path of `./.layer-playground` in that `tsconfig` would point to `basic/.nuxt/.layer-playground` instead of the correct `basic/.layer-playground`.
![wrong-path](https://github.com/nuxt/learn.nuxt.com/assets/44749100/f12b4b39-33ee-44cb-893c-e01d29457296)
Thus, the correct `include` should be  `../.layer-playground/**/*`.
![is2](https://github.com/nuxt/learn.nuxt.com/assets/44749100/17291842-4f2e-48b1-a219-81dfb7d9d89b)

