### PR TITLE
feat: Disable saving with Ctrl/Cmd + S in Monaco Editor.

### DIFF
--- a/components/PanelEditorMonaco.client.vue
+++ b/components/PanelEditorMonaco.client.vue
@@ -108,6 +108,8 @@ watch(
       emit('change', value)
     })
 
+    editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyS, () => {})
+
     watch(
       () => props.filepath,
       () => {


### PR DESCRIPTION
Hello! Antfu! I think when users hit Ctrl/Cmd + S in the Monaco Editor, we'll skip saving the page?