### PR TITLE
fix: Monaco Editor tooltip obscuring API descriptions.

### DIFF
--- a/components/PanelEditorMonaco.client.vue
+++ b/components/PanelEditorMonaco.client.vue
@@ -99,6 +99,7 @@ watch(
         },
         'semanticHighlighting.enabled': true,
         'overviewRulerLanes': 0,
+        'fixedOverflowWidgets': true,
       },
     )
 


### PR DESCRIPTION
Hello! Antfu!Tooltip gets cut off a bit when hovering over variables at the top or close to the edge. Should we fix this?
Before:
![image](https://github.com/nuxt/learn.nuxt.com/assets/47271407/92c01467-9cd3-434d-8290-817500daf5e2)
After:
![image](https://github.com/nuxt/learn.nuxt.com/assets/47271407/62508911-8201-402f-a7fc-14cad022f1c7)
