### PR TITLE
fix: persist scroll position of terminal

### DIFF
--- a/components/PanelTerminalClient.client.vue
+++ b/components/PanelTerminalClient.client.vue
@@ -29,6 +29,7 @@ const terminal = new Terminal({
   fontFamily: 'DM Mono, monospace',
 })
 
+// persist the scroll position of terminal
 const ui = useUiState()
 watch(() => ui.showTerminal, (v) => {
   if (!root.value)

--- a/components/PanelTerminalClient.client.vue
+++ b/components/PanelTerminalClient.client.vue
@@ -29,6 +29,19 @@ const terminal = new Terminal({
   fontFamily: 'DM Mono, monospace',
 })
 
+const ui = useUiState()
+watch(() => ui.showTerminal, (v) => {
+  if (!root.value)
+    return
+  if (!v) {
+    const { height } = root.value.getBoundingClientRect()
+    root.value.style.height = `${height}px`
+  }
+  else {
+    root.value.style.height = 'initial'
+  }
+}, { flush: 'sync' })
+
 watch(
   () => theme.value,
   (t) => {


### PR DESCRIPTION
I notice that everytime I toggle the terminal the scroll positioin will change a little bit.

I find a workaround.