### PR TITLE
feat: dynamic navItem opening based on route path

### DIFF
--- a/components/ContentNavItem.vue
+++ b/components/ContentNavItem.vue
@@ -25,7 +25,7 @@ const paddingLeft = computed(() => `${0.5 + props.level * 0.8}rem`)
 <template>
   <div class="content-nav-item">
     <template v-if="resolved.children?.length">
-      <details>
+      <details :open="$route.path.includes(resolved._path)">
         <summary>
           <div
             flex="~ gap-1 items-center" cursor-pointer select-none px1 py0.5
@@ -52,6 +52,7 @@ const paddingLeft = computed(() => `${0.5 + props.level * 0.8}rem`)
       :to="resolved._path"
       px1 py0.5
       :style="{ paddingLeft }"
+      :class="{ 'text-primary bg-active': resolved._path === $route.path }"
       flex="~ gap-1 items-center"
       hover="text-primary bg-active "
       @click="ui.isContentDropdownShown = false"


### PR DESCRIPTION
sorry I forgot to open an issue again first, but I think this is a simple PR.
this PR adds support to update content-nav-item component to dynamically open details based on route path. (for example after a refresh). also shows the active item by adding primary color to it.


<img width="737" alt="Screenshot 2024-03-18 at 12 43 53 PM" src="https://github.com/nuxt/learn.nuxt.com/assets/38922203/b6619672-e92b-408a-9202-64c05ec65d8c">
