### PR TITLE
Switch to using my maintained fork of splitpanes over the unmaintained version

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "jszip": "^3.10.1",
     "monaco-editor": "^0.50.0",
     "shiki": "^1.10.0",
-    "splitpanes": "^3.1.5",
+    "splitpanes4": "^4.0.2",
     "strip-json-comments": "^5.0.1",
     "theme-vitesse": "^0.8.0",
     "unified": "^11.0.5",


### PR DESCRIPTION
I've updated vue, vite and am in the process of switching from the options api to composition api with typescript as well as switching from pug templating syntax to the normal vue html templating syntax.

Should also help with fixing issues like #129 