### PR TITLE
fix: preview refresh button is now shown

### DIFF
--- a/components/PanelPreview.vue
+++ b/components/PanelPreview.vue
@@ -77,7 +77,7 @@ function navigate() {
         <span text-sm>Preview</span>
       </div>
       <button
-        v-if="preview.url && guide.features.navigation"
+
         rounded p1
         hover="bg-active"
         title="Refresh Preview"


### PR DESCRIPTION
<!--

Hey! Thanks for your contribution!

Just a quick note, this project is progressed mainly on Live Streams (https://github.com/nuxt/learn.nuxt.com#live-streaming). That means for significant changes, we want to demonstrate them on the stream so people can follow along the whole process.

**Please create an issue first before submiting PRs**. So that we can discuss about the directions and plans, to avoid wasted efforts. Thank you!

-->
issue: #178 
the button was supposed to be shown but it never did, i don't know what was the purpose of checking `preview.url` and guide.features.navigation` but doing so made the refresh button never show.