### PR TITLE
fix: PanelDocs overflows container

### DIFF
--- a/components/PanelDocs.vue
+++ b/components/PanelDocs.vue
@@ -144,9 +144,8 @@ router.beforeEach(() => {
           v-if="ui.isContentDropdownShown"
           flex="~ col"
           border="b base"
-          absolute left-0 right-0 top-0 max-h-60vh py2
-          backdrop-blur-10 bg-base important-bg-opacity-80
-          overflow-y-auto
+
+          absolute left-0 right-0 top-0 max-h-60vh overflow-y-auto py2 backdrop-blur-10 bg-base important-bg-opacity-80
         >
           <ContentNavItem v-for="item of navigation" :key="item.path" :item="item" />
         </div>

--- a/components/PanelDocs.vue
+++ b/components/PanelDocs.vue
@@ -146,6 +146,7 @@ router.beforeEach(() => {
           border="b base"
           absolute left-0 right-0 top-0 max-h-60vh py2
           backdrop-blur-10 bg-base important-bg-opacity-80
+          overflow-y-auto
         >
           <ContentNavItem v-for="item of navigation" :key="item.path" :item="item" />
         </div>


### PR DESCRIPTION
(~Didn't test the attribute class works -- but~ preview shows this part is working; see before/after with `overflow-y:auto` below)

![2025-03-25_11-12](https://github.com/user-attachments/assets/17ac1157-c2f7-4f63-aeb1-9207a0e30513)
![2025-03-25_11-13](https://github.com/user-attachments/assets/750712c2-7b27-4b91-9cca-4723ccad0e6f)
