### PR TITLE
fix: correct terminology from "概念" to "コンセプト" in Japanese content

### DIFF
--- a/content/ja/0.index.md
+++ b/content/ja/0.index.md
@@ -9,7 +9,7 @@ ogImage:
 
 # Nuxt チュートリアルへようこそ！
 
-これは、ガイドとチャレンジで構成されたインタラクティブなチュートリアルで、[Nuxt](https://nuxt.com/) とその概念をステップバイステップで学ぶのに役立ちます。
+これは、ガイドとチャレンジで構成されたインタラクティブなチュートリアルで、[Nuxt](https://nuxt.com/) とそのコンセプトをステップバイステップで学ぶのに役立ちます。
 
 このチュートリアルの目的は、**ブラウザだけ**で Nuxt と Vue を使って開発する感覚をすばやく体験してもらうことです。包括的に理解することは目指しておらず、次に進む前にすべてを理解する必要はありません。全てのプレイグラウンドは、フル機能のエディタと開発環境で編集可能なので、コードを操作してすぐに結果を見ることができ、実際に作りながら学ぶことができます。
 
@@ -19,18 +19,18 @@ Nuxt は、[Vue.js](https://vuejs.org) を使用して、型安全でパフォ�
 
 ## はじめに
 
-このチュートリアルでは、HTML、CSS、JavaScript の基本的な概念に既に精通していることを前提としています。Nuxt は [Vue](https://vuejs.org) の上に構築されたフルスタックフレームワークのため、Vue の基本的なチュートリアルも提供しています。
+このチュートリアルでは、HTML、CSS、JavaScript の基本的なコンセプトに既に精通していることを前提としています。Nuxt は [Vue](https://vuejs.org) の上に構築されたフルスタックフレームワークのため、Vue の基本的なチュートリアルも提供しています。
 
 以下のトピックをクリックして学習を始めてください：
 
 ::div{.flex.flex-wrap.gap-2}
 :content-card{to="/ja/vue" title="Vue の基本" description="Vue に馴染みがない場合は、まず Vue の基本を学んでください。" icon="i-logos-vue"}
-:content-card{to="/ja/concepts" title="Nuxt の概念" description="Nuxt のコアコンセプトについて学びます。" icon="i-logos-nuxt-icon"}
+:content-card{to="/ja/concepts" title="Nuxt のコンセプト" description="Nuxt のコアコンセプトについて学びます。" icon="i-logos-nuxt-icon"}
 ::
 
 ## ケーススタディ
 
-Vue と Nuxt の概念に既に精通している人向けに、実際のアプリケーションで Nuxt をどのように使用するかを理解するためのケーススタディを提供しています：
+Vue と Nuxt のコンセプトに既に精通している人向けに、実際のアプリケーションで Nuxt をどのように使用するかを理解するためのケーススタディを提供しています：
 
 ::div{.flex.flex-wrap.gap-2}
 :content-card{to="/ja" wip title="GitHub プロフィール" description="GitHub のカスタムユーザープロフィールを生成するウェブサイトを作成します" icon="i-ph-user-circle-duotone"}


### PR DESCRIPTION
This pull request includes minor updates to the Japanese translation of the Nuxt tutorial to improve consistency in terminology. The changes involve replacing the word "概念" with "コンセプト" to ensure uniformity throughout the document.

Key changes:

* [`content/ja/0.index.md`](diffhunk://#diff-98a481b2459667fc96cdc894868e1c063ea73762ce036ccc35189f55698f5618L12-R12): Replaced "概念" with "コンセプト" in multiple instances to maintain consistency in terminology. [[1]](diffhunk://#diff-98a481b2459667fc96cdc894868e1c063ea73762ce036ccc35189f55698f5618L12-R12) [[2]](diffhunk://#diff-98a481b2459667fc96cdc894868e1c063ea73762ce036ccc35189f55698f5618L22-R33)