### PR TITLE
chore: introduce eslint-plugin-vue-i18n

### DIFF
--- a/components/PanelEditor.vue
+++ b/components/PanelEditor.vue
@@ -69,7 +69,7 @@ const panelInitEditor = computed(() => isMounted.value || {
           bg-faded px4 py2
         >
           <div i-ph-tree-structure-duotone />
-          <span text-sm>Files</span>
+          <span text-sm>{{ $t('files') }}</span>
         </div>
         <div py2>
           <PanelEditorFileSystemTree

--- a/components/PanelPreview.vue
+++ b/components/PanelPreview.vue
@@ -53,7 +53,7 @@ function navigate() {
         m1.5 rounded bg-faded px2 py0.5 tracking-wide
       >
         <div i-ph-globe-duotone />
-        <span text-sm op50>Preview</span>
+        <span text-sm op50>{{ $t('preview') }}</span>
         <div
           text-sm
           flex="~ items-center justify-center auto"
@@ -74,7 +74,7 @@ function navigate() {
         flex="~ gap-2 auto items-center" px2 py2
       >
         <div i-ph-globe-duotone />
-        <span text-sm>Preview</span>
+        <span text-sm>{{ $t('preview') }}</span>
       </div>
       <button
 
@@ -97,22 +97,26 @@ function navigate() {
           <div px5 py4 grid="~ gap-y-3 gap-x-2 cols-[max-content_1fr] items-center">
             <div i-uim-vuejs text-xl />
             <div flex="~ gap-2 items-center">
-              Vue version:
+              <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -->
+              {{ $t('vueVersion') }}:
               <div
                 v-if="!preview.clientInfo?.versionVue"
                 i-svg-spinners-90-ring-with-bg
               />
+              <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -->
               <code v-else>
                 v{{ preview.clientInfo.versionVue }}
               </code>
             </div>
             <div i-simple-icons-nuxtdotjs text-xl />
             <div flex="~ gap-2 items-center">
-              Nuxt version:
+              <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -->
+              {{ $t('nuxtVersion') }}:
               <div
                 v-if="!preview.clientInfo?.versionNuxt"
                 i-svg-spinners-90-ring-with-bg
               />
+              <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -->
               <code v-else>
                 v{{ preview.clientInfo.versionNuxt }}
               </code>

--- a/components/TheNav.vue
+++ b/components/TheNav.vue
@@ -141,7 +141,8 @@ addCommands(
             <div i-ph-package-duotone text-xl />
             <NuxtLink :to="`${runtime.public.repoUrl}/commit/${runtime.public.gitSha}`" target="_blank" title="View on GitHub">
               <time :datetime="buildTime.toISOString()" :title="buildTime.toLocaleString()">
-                Built {{ timeAgo }} (<code>{{ runtime.public.gitSha.slice(0, 5) }}</code>)
+                <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -->
+                {{ $t('built') }} {{ timeAgo }} (<code>{{ runtime.public.gitSha.slice(0, 5) }}</code>)
               </time>
             </NuxtLink>
           </div>

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,4 +1,5 @@
 import antfu from '@antfu/eslint-config'
+import vueI18n from '@intlify/eslint-plugin-vue-i18n'
 import nuxt from './.nuxt/eslint.config.mjs'
 
 export default antfu(
@@ -21,3 +22,24 @@ export default antfu(
   .override('antfu/pnpm/package-json', {
     ignores: ['**/templates/**'],
   })
+  .append(
+    vueI18n.configs.recommended,
+    {
+      settings: {
+        'vue-i18n': {
+          localeDir: 'i18n/locales/*.yaml',
+        },
+      },
+      rules: {
+        '@intlify/vue-i18n/no-missing-keys': 'error',
+        '@intlify/vue-i18n/no-raw-text': 'error',
+        '@intlify/vue-i18n/no-deprecated-modulo-syntax': 'off',
+      },
+    },
+    {
+      files: ['content/**'],
+      rules: {
+        '@intlify/vue-i18n/no-raw-text': 'off',
+      },
+    },
+  )

--- a/i18n/locales/en.yaml
+++ b/i18n/locales/en.yaml
@@ -23,3 +23,8 @@ steps:
   waiting-for-nuxt-to-ready: Waiting for Nuxt to ready
 restart-server: Restart the server
 interactive-terminal-mode: Interactive terminal mode
+files: Files
+preview: Preview
+built: Built
+vueVersion: Vue version
+nuxtVersion: Nuxt version

--- a/i18n/locales/ja.yaml
+++ b/i18n/locales/ja.yaml
@@ -23,3 +23,8 @@ steps:
   waiting-for-nuxt-to-ready: Nuxtが準備完了を待機中
 restart-server: サーバーを再起動
 interactive-terminal-mode: インタラクティブターミナルモード
+files: ファイル
+preview: プレビュー
+built: ビルド
+vueVersion: Vueバージョン
+nuxtVersion: Nuxtバージョン

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@iconify-json/logos": "catalog:icons",
     "@iconify-json/ph": "catalog:icons",
     "@iconify-json/svg-spinners": "catalog:icons",
+    "@intlify/eslint-plugin-vue-i18n": "catalog:dev",
     "@nuxt/content": "catalog:nuxt",
     "@nuxt/devtools": "catalog:nuxt",
     "@nuxt/eslint": "catalog:nuxt",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,9 @@ catalogs:
     '@antfu/eslint-config':
       specifier: ^4.11.0
       version: 4.11.0
+    '@intlify/eslint-plugin-vue-i18n':
+      specifier: ^4.0.1
+      version: 4.0.1
     '@unocss/eslint-plugin':
       specifier: ^65.5.0
       version: 65.5.0
@@ -251,6 +254,9 @@ importers:
       '@iconify-json/svg-spinners':
         specifier: catalog:icons
         version: 1.2.2
+      '@intlify/eslint-plugin-vue-i18n':
+        specifier: catalog:dev
+        version: 4.0.1(eslint@9.24.0(jiti@2.4.2))(jsonc-eslint-parser@2.4.0)(vue-eslint-parser@10.1.1(eslint@9.24.0(jiti@2.4.2)))(yaml-eslint-parser@1.3.0)
       '@nuxt/content':
         specifier: catalog:nuxt
         version: 3.4.0(magicast@0.3.5)(typescript@5.8.3)
@@ -486,6 +492,10 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+
+  '@babel/runtime@7.27.0':
+    resolution: {integrity: sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/template@7.26.9':
     resolution: {integrity: sha512-qyRplbeIpNZhmzOysF/wFMuP9sctmh2cFzRAZOn1YapxBsE1i9bJIY586R/WBLfLcmcBlM8ROBiQURnnNy+zfA==}
@@ -1011,9 +1021,22 @@ packages:
     resolution: {integrity: sha512-/NINGvy7t8qSCyyuqMIPmHS6CBQjqPIPVOps0Rb7xWrwwkwHJKtahiFnW1HC4iQVhzoYwEW6Js0923zTScLDiA==}
     engines: {node: '>= 16'}
 
+  '@intlify/core-base@11.1.3':
+    resolution: {integrity: sha512-cMuHunYO7LE80azTitcvEbs1KJmtd6g7I5pxlApV3Jo547zdO3h31/0uXpqHc+Y3RKt1wo2y68RGSx77Z1klyA==}
+    engines: {node: '>= 16'}
+
   '@intlify/core@10.0.6':
     resolution: {integrity: sha512-C325rIyg5+wM6FUPbTMTaDPQ3Yu9lwC9JRIaWZKVy+My3kXi0j0u76ifQ351CjqFoJDg7GLR/UpUPQlF25qhKQ==}
     engines: {node: '>= 16'}
+
+  '@intlify/eslint-plugin-vue-i18n@4.0.1':
+    resolution: {integrity: sha512-xZKG7EvMvvumK9sdpnt6Dxa/dxV6/05/hRXIgJc0XI4l0+QUnyfdz5qXEvDm21T+OQsFN0CK/C+p0Fpra2wscQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      eslint: ^8.0.0 || ^9.0.0-0
+      jsonc-eslint-parser: ^2.3.0
+      vue-eslint-parser: ^10.0.0
+      yaml-eslint-parser: ^1.2.2
 
   '@intlify/h3@0.6.1':
     resolution: {integrity: sha512-hFMcqWXCoFNZkraa+JF7wzByGdE0vGi8rUs7CTFrE4hE3X2u9QcelH8VRO8mPgJDH+TgatzvrVp6iZsWVluk2A==}
@@ -1027,12 +1050,20 @@ packages:
     resolution: {integrity: sha512-T/xbNDzi+Yv0Qn2Dfz2CWCAJiwNgU5d95EhhAEf4YmOgjCKktpfpiUSmLcBvK1CtLpPQ85AMMQk/2NCcXnNj1g==}
     engines: {node: '>= 16'}
 
+  '@intlify/message-compiler@11.1.3':
+    resolution: {integrity: sha512-7rbqqpo2f5+tIcwZTAG/Ooy9C8NDVwfDkvSeDPWUPQW+Dyzfw2o9H103N5lKBxO7wxX9dgCDjQ8Umz73uYw3hw==}
+    engines: {node: '>= 16'}
+
   '@intlify/shared@10.0.6':
     resolution: {integrity: sha512-2xqwm05YPpo7TM//+v0bzS0FWiTzsjpSMnWdt7ZXs5/ZfQIedSuBXIrskd8HZ7c/cZzo1G9ALHTksnv/74vk/Q==}
     engines: {node: '>= 16'}
 
   '@intlify/shared@11.1.2':
     resolution: {integrity: sha512-dF2iMMy8P9uKVHV/20LA1ulFLL+MKSbfMiixSmn6fpwqzvix38OIc7ebgnFbBqElvghZCW9ACtzKTGKsTGTWGA==}
+    engines: {node: '>= 16'}
+
+  '@intlify/shared@11.1.3':
+    resolution: {integrity: sha512-pTFBgqa/99JRA2H1qfyqv97MKWJrYngXBA/I0elZcYxvJgcCw3mApAoPW3mJ7vx3j+Ti0FyKUFZ4hWxdjKaxvA==}
     engines: {node: '>= 16'}
 
   '@intlify/unplugin-vue-i18n@6.0.5':
@@ -4041,6 +4072,9 @@ packages:
     resolution: {integrity: sha512-K55T22lfpQ63N4KEN57jZUAaAYqYHEe8veb/TycJRk9DdSCLLcovXz/mL6mOnhQaZsQGwPhuFopdQIlqGSEjiQ==}
     engines: {node: '>=18'}
 
+  is-language-code@3.1.0:
+    resolution: {integrity: sha512-zJdQ3QTeLye+iphMeK3wks+vXSRFKh68/Pnlw7aOfApFSEIOhYa8P9vwwa6QrImNNBMJTiL1PpYF0f4BxDuEgA==}
+
   is-module@1.0.0:
     resolution: {integrity: sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==}
 
@@ -5198,6 +5232,9 @@ packages:
     resolution: {integrity: sha512-J8rn6v4DBb2nnFqkqwy6/NnTYMcgLA+sLr0iIO41qpv0n+ngb7ksag2tMRl0inb1bbO/esUwzW1vbJi7K0sI0g==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
+  regenerator-runtime@0.14.1:
+    resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
+
   regex-recursion@6.0.2:
     resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
 
@@ -5592,6 +5629,10 @@ packages:
     resolution: {integrity: sha512-OoohrmuUlBs8B8o6MB2Aevn+pRIH9zDALSR+6hhqVfa6fRwG/Qw9VUMSMW9VNg2CFc/MTIfabtdOVl9ODIJjpw==}
     engines: {node: '>=14.0.0'}
     hasBin: true
+
+  synckit@0.10.3:
+    resolution: {integrity: sha512-R1urvuyiTaWfeCggqEvpDJwAlDVdsT9NM+IP//Tk2x7qHCkSvBk/fwFgw/TLAHzZlrAnnazMcRw0ZD8HlYFTEQ==}
+    engines: {node: ^14.18.0 || >=16.0.0}
 
   synckit@0.6.2:
     resolution: {integrity: sha512-Vhf+bUa//YSTYKseDiiEuQmhGCoIF3CVBhunm3r/DQnYiGT4JssmnKQc44BIyOZRK2pKjXXAgbhfmbeoC9CJpA==}
@@ -6567,6 +6608,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/runtime@7.27.0':
+    dependencies:
+      regenerator-runtime: 0.14.1
+
   '@babel/template@7.26.9':
     dependencies:
       '@babel/code-frame': 7.26.2
@@ -7008,10 +7053,40 @@ snapshots:
       '@intlify/message-compiler': 10.0.6
       '@intlify/shared': 10.0.6
 
+  '@intlify/core-base@11.1.3':
+    dependencies:
+      '@intlify/message-compiler': 11.1.3
+      '@intlify/shared': 11.1.3
+
   '@intlify/core@10.0.6':
     dependencies:
       '@intlify/core-base': 10.0.6
       '@intlify/shared': 10.0.6
+
+  '@intlify/eslint-plugin-vue-i18n@4.0.1(eslint@9.24.0(jiti@2.4.2))(jsonc-eslint-parser@2.4.0)(vue-eslint-parser@10.1.1(eslint@9.24.0(jiti@2.4.2)))(yaml-eslint-parser@1.3.0)':
+    dependencies:
+      '@eslint/eslintrc': 3.3.1
+      '@intlify/core-base': 11.1.3
+      '@intlify/message-compiler': 11.1.3
+      debug: 4.4.0
+      eslint: 9.24.0(jiti@2.4.2)
+      eslint-compat-utils: 0.6.4(eslint@9.24.0(jiti@2.4.2))
+      glob: 10.4.5
+      globals: 16.0.0
+      ignore: 7.0.3
+      import-fresh: 3.3.1
+      is-language-code: 3.1.0
+      js-yaml: 4.1.0
+      json5: 2.2.3
+      jsonc-eslint-parser: 2.4.0
+      lodash: 4.17.21
+      parse5: 7.2.1
+      semver: 7.7.1
+      synckit: 0.10.3
+      vue-eslint-parser: 10.1.1(eslint@9.24.0(jiti@2.4.2))
+      yaml-eslint-parser: 1.3.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@intlify/h3@0.6.1':
     dependencies:
@@ -7028,9 +7103,16 @@ snapshots:
       '@intlify/shared': 11.1.2
       source-map-js: 1.2.1
 
+  '@intlify/message-compiler@11.1.3':
+    dependencies:
+      '@intlify/shared': 11.1.3
+      source-map-js: 1.2.1
+
   '@intlify/shared@10.0.6': {}
 
   '@intlify/shared@11.1.2': {}
+
+  '@intlify/shared@11.1.3': {}
 
   '@intlify/unplugin-vue-i18n@6.0.5(@vue/compiler-dom@3.5.13)(eslint@9.24.0(jiti@2.4.2))(rollup@4.37.0)(typescript@5.8.3)(vue-i18n@10.0.6(vue@3.5.13(typescript@5.8.3)))(vue@3.5.13(typescript@5.8.3))':
     dependencies:
@@ -10839,6 +10921,10 @@ snapshots:
       global-directory: 4.0.1
       is-path-inside: 4.0.0
 
+  is-language-code@3.1.0:
+    dependencies:
+      '@babel/runtime': 7.27.0
+
   is-module@1.0.0: {}
 
   is-number@7.0.0: {}
@@ -12444,6 +12530,8 @@ snapshots:
     dependencies:
       '@eslint-community/regexpp': 4.12.1
 
+  regenerator-runtime@0.14.1: {}
+
   regex-recursion@6.0.2:
     dependencies:
       regex-utilities: 2.3.0
@@ -12972,6 +13060,11 @@ snapshots:
       css-what: 6.1.0
       csso: 5.0.5
       picocolors: 1.1.1
+
+  synckit@0.10.3:
+    dependencies:
+      '@pkgr/core': 0.2.1
+      tslib: 2.8.1
 
   synckit@0.6.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,7 @@ patchedDependencies:
 catalogs:
   dev:
     '@antfu/eslint-config': ^4.11.0
+    '@intlify/eslint-plugin-vue-i18n': ^4.0.1
     '@unocss/eslint-plugin': ^65.5.0
     eslint: ^9.24.0
     eslint-plugin-format: ^1.0.1


### PR DESCRIPTION
Hi dear @antfu,

I believe we recently added i18n support in #217, and there's actually an amazing linter specifically for that purpose.

https://github.com/intlify/eslint-plugin-vue-i18n

This linter can catch raw text in templates as well as missing message keys.  

<img width="736" alt="Screenshot 2025-04-11 at 2 09 14" src="https://github.com/user-attachments/assets/df6243f9-6781-4248-87a3-cc46a4dbe6b0" />

<img width="736" alt="Screenshot 2025-04-11 at 2 09 45" src="https://github.com/user-attachments/assets/a2fb57a3-faa3-4346-a98f-1da426d3d4f9" />


~~I went ahead and tried introducing it, and while it caught some raw text issues, what do you think about going ahead and fixing those?~~

~~If so, I’m happy to help with the work — but if you’d prefer to cover this again on a livestream, then consider this just a suggestion and I’ll leave it to you!~~
