### PR TITLE
fix: remove duplicated locale segment in source URL

### DIFF
--- a/components/PanelDocs.vue
+++ b/components/PanelDocs.vue
@@ -81,7 +81,7 @@ const ui = useUiState()
 
 const sourceUrl = computed(() =>
   page.value?.id
-    ? `${runtime.public.repoUrl}/edit/main/content/${page.value.id}`
+    ? `${runtime.public.repoUrl}/edit/main/content/${page.value.stem}.${page.value.extension}`
     : undefined,
 )
 


### PR DESCRIPTION
[Issue#226](https://github.com/nuxt/learn.nuxt.com/issues/226)

When generating the edit URL for content files, the `ja/` segment was being appended twice, resulting in paths like `ja/ja/...`. This fix ensures the path is generated correctly with only a single `ja/`.