### PR TITLE
fix: typo in computed property name

### DIFF
--- a/content/en/1.vue/2.reactivity/index.md
+++ b/content/en/1.vue/2.reactivity/index.md
@@ -10,9 +10,9 @@ Vue provides [a great reactivity system](https://vuejs.org/guide/essentials/reac
 
 - [`computed()`](https://vuejs.org/api/reactivity-core.html#computed) takes a getter function and returns a `ref` object, that reflects the return value of the getter function.
 
-Here in the playground, we've created a ref object named `count` to hold a number, and a computed object named `double` that calculates the double of `count`. Vue will smartly know that `double` depends on `count`, so whenever `count` changes, `double` will re-calculate automatically.
+Here in the playground, we've created a ref object named `count` to hold a number, and a computed object named `doubled` that calculates the double of `count`. Vue will smartly know that `doubled` depends on `count`, so whenever `count` changes, `doubled` will re-calculate automatically.
 
-Try clicking the button to increase the `count` value - you will see that the value of `double` also reflects the change.
+Try clicking the button to increase the `count` value - you will see that the value of `doubled` also reflects the change.
 
 ::note
 **Note**: Refs will be [auto unwrapped by Vue](https://vuejs.org/guide/essentials/reactivity-fundamentals.html#declaring-reactive-state-1) when referenced in the `<template>`, The `.value` is only needed when accessing the ref in `<script>` or JavaScript outside of Vue components.
@@ -25,7 +25,7 @@ Now let's get our hands on it! Try modifying the code to make the multiplier als
 To do that, you can:
 
 1. Create a variable named `multiplier` with `ref()` and set it to `2`
-2. Rename `double` to `result` in both the `<script>` and `<template>`
+2. Rename `doubled` to `result` in both the `<script>` and `<template>`
 3. Update the implementation of `result` to return `count.value * multiplier.value`{lang=js}
 4. Add another button to increase the `multiplier` value
 


### PR DESCRIPTION
In the code editor it is used the `doubled` computed property, but on the content side bar is used `double`. I changed it to reflect the name used in the editor to avoid confusion.

<!--

Hey! Thanks for your contribution!

Just a quick note, this project is progressed mainly on Live Streams (https://github.com/nuxt/learn.nuxt.com#live-streaming). That means for significant changes, we want to demonstrate them on the stream so people can follow along the whole process.

**Please create an issue first before submiting PRs**. So that we can discuss about the directions and plans, to avoid wasted efforts. Thank you!

-->
