### PR TITLE
fix: remove unused prop 'message' from Child component

### DIFF
--- a/content/ja/1.vue/5.components/.template/solutions/Child.vue
+++ b/content/ja/1.vue/5.components/.template/solutions/Child.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 defineProps<{
-  message: string
   name: string
 }>()
 


### PR DESCRIPTION
<!--

Hey! Thanks for your contribution!

Just a quick note, this project is progressed mainly on Live Streams (https://github.com/nuxt/learn.nuxt.com#live-streaming). That means for significant changes, we want to demonstrate them on the stream so people can follow along the whole process.

**Please create an issue first before submiting PRs**. So that we can discuss about the directions and plans, to avoid wasted efforts. Thank you!

-->

### 📚 Description


Remove unused message prop that was causing console warning.

The content is passed via <slot name="paragraph"> instead of props, so the message prop definition was unnecessary.

Console warning before fix

```bash
  [3:17:19]  WARN  [Vue warn]: Missing required prop: "message"
    at <Child name="John Doe" onUpdate:name=fn<updateName> >
    at <App>
    at <NuxtRoot>
```

  | Before | After |
  |--------|-------|
  |   <img width="1351" height="1250" alt="スクリーンショット 2025-09-24 3 26 58" src="https://github.com/user-attachments/assets/d48eb9d7-36fd-48d9-b51f-9e81cfe15c55" />     |    <img width="1341" height="1287" alt="スクリーンショット 2025-09-24 3 27 22" src="https://github.com/user-attachments/assets/14b83b70-29b2-4c5e-a899-16f3dddd2f4e" />