### PR TITLE
fix: typo

### DIFF
--- a/content/ja/9.workspace/1.todo-list/5.componentization-1/index.md
+++ b/content/ja/9.workspace/1.todo-list/5.componentization-1/index.md
@@ -155,10 +155,10 @@ app.vueに定義されたtodosにTodoList.vueからアクセスすることが�
 
 `props` と `emit` を使用して親子間でデータのやり取りをできるようにしましょう：
 
-2. `TodoList.vue`で`defineProps`を使用して親から`todos`を受け取れるようにしましょう
-3. `app.vue`に`<TodoList />`を配置して、todosを渡してみましょう。
-4. `TodoList.vue`で`defineEmits`を使用してアイコンのクリックイベントを親に伝えられるようにしましょう
-5. `app.vue`で`TodoList.vue`から受け取ったイベントを利用して`updateDone`を実行しましょう
+1. `TodoList.vue`で`defineProps`を使用して親から`todos`を受け取れるようにしましょう
+2. `app.vue`に`<TodoList />`を配置して、todosを渡してみましょう。
+3. `TodoList.vue`で`defineEmits`を使用してアイコンのクリックイベントを親に伝えられるようにしましょう
+4. `app.vue`で`TodoList.vue`から受け取ったイベントを利用して`updateDone`を実行しましょう
 
 参考実装：
 


### PR DESCRIPTION
<!--

Hey! Thanks for your contribution!

Just a quick note, this project is progressed mainly on Live Streams (https://github.com/nuxt/learn.nuxt.com#live-streaming). That means for significant changes, we want to demonstrate them on the stream so people can follow along the whole process.

**Please create an issue first before submiting PRs**. So that we can discuss about the directions and plans, to avoid wasted efforts. Thank you!

-->

For Vue Fes Japan 2025.

## Before

<img width="573" height="375" alt="スクリーンショット 2025-09-28 14 57 40" src="https://github.com/user-attachments/assets/972c8b0b-a7f6-44a0-aef1-93de05cea353" />

## After

<img width="573" height="375" alt="スクリーンショット 2025-09-28 14 58 20" src="https://github.com/user-attachments/assets/e75ff439-4e40-4eb5-88d2-beabcc5904d1" />
